### PR TITLE
Fix check service contains in portainer

### DIFF
--- a/src/retainer.py
+++ b/src/retainer.py
@@ -131,7 +131,7 @@ class Portainer:
         response = self.api_request('api/endpoints/%d/docker/services' % endpoint, token=token)
 
         for service in response.json():
-            if image == service['Spec']['TaskTemplate']['ContainerSpec']['Image']:
+            if image in service['Spec']['TaskTemplate']['ContainerSpec']['Image']:
                 result.append(service)
 
                 self.restart_service(


### PR DESCRIPTION
Verificando se parte do nome da imagem selecionada está presente no Portainer, pois em alguns casos o hash do commit também é inserido no nome da imagem